### PR TITLE
Workaround TiDB missing AUTO_INCREMENT via HasManualAutoIncrement trait

### DIFF
--- a/app/Models/Concerns/HasManualAutoIncrement.php
+++ b/app/Models/Concerns/HasManualAutoIncrement.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models\Concerns;
+
+use Illuminate\Support\Facades\DB;
+
+trait HasManualAutoIncrement
+{
+    protected static function bootHasManualAutoIncrement(): void
+    {
+        static::creating(function ($model) {
+            $key = $model->getKeyName();
+            if (empty($model->{$key})) {
+                $model->{$key} = (int) DB::table($model->getTable())->max($key) + 1;
+            }
+        });
+    }
+}

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\HasManualAutoIncrement;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -14,6 +15,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 class Group extends Model
 {
     use HasFactory;
+    use HasManualAutoIncrement;
 
     protected $table = 'groups';
 

--- a/app/Models/GroupMember.php
+++ b/app/Models/GroupMember.php
@@ -2,12 +2,14 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasManualAutoIncrement;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class GroupMember extends Model
 {
     use HasFactory;
+    use HasManualAutoIncrement;
 
     protected $table = 'group_member';
 }

--- a/app/Models/InvoiceGroup.php
+++ b/app/Models/InvoiceGroup.php
@@ -2,12 +2,14 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasManualAutoIncrement;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class InvoiceGroup extends Model
 {
     use HasFactory;
+    use HasManualAutoIncrement;
 
     protected $table = 'invoice_groups';
 

--- a/app/Models/InvoiceLine.php
+++ b/app/Models/InvoiceLine.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasManualAutoIncrement;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -9,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 class InvoiceLine extends Model
 {
     use HasFactory;
+    use HasManualAutoIncrement;
 
     protected $table = 'invoice_lines';
 

--- a/app/Models/InvoiceProduct.php
+++ b/app/Models/InvoiceProduct.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasManualAutoIncrement;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,6 +11,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class InvoiceProduct extends Model
 {
     use HasFactory;
+    use HasManualAutoIncrement;
 
     protected $table = 'invoice_products';
 

--- a/app/Models/InvoiceProductPrice.php
+++ b/app/Models/InvoiceProductPrice.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasManualAutoIncrement;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -10,6 +11,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class InvoiceProductPrice extends Model
 {
     use HasFactory;
+    use HasManualAutoIncrement;
 
     protected $table = 'invoice_product_prices';
 

--- a/app/Models/Member.php
+++ b/app/Models/Member.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\HasManualAutoIncrement;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -14,6 +15,7 @@ use Illuminate\Database\Eloquent\Relations\MorphMany;
 class Member extends Model
 {
     use HasFactory;
+    use HasManualAutoIncrement;
 
     protected $table = 'members';
 

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\HasManualAutoIncrement;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -13,6 +14,7 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 class Order extends Model
 {
     use HasFactory;
+    use HasManualAutoIncrement;
 
     protected $table = 'orders';
 

--- a/app/Models/Product.php
+++ b/app/Models/Product.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\HasManualAutoIncrement;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -11,6 +12,7 @@ use Illuminate\Database\Eloquent\Model;
 class Product extends Model
 {
     use HasFactory;
+    use HasManualAutoIncrement;
 
     protected $table = 'products';
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use App\Models\Concerns\HasManualAutoIncrement;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -11,6 +12,7 @@ use Illuminate\Notifications\Notifiable;
 class User extends Authenticatable
 {
     use HasFactory;
+    use HasManualAutoIncrement;
     use Notifiable;
 
     /**


### PR DESCRIPTION
## Summary

- Adds `App\Models\Concerns\HasManualAutoIncrement` trait that hooks into Eloquent's `creating` event and sets `id = MAX(id) + 1` before each insert
- Applied to all 10 models: `Group`, `GroupMember`, `InvoiceGroup`, `InvoiceLine`, `InvoiceProduct`, `InvoiceProductPrice`, `Member`, `Order`, `Product`, `User`

This is a workaround for TiDB not supporting `ALTER TABLE ... MODIFY id INT AUTO_INCREMENT` on existing tables. It avoids having to drop and recreate tables.

> **Note:** There is a theoretical race condition if two rows are inserted into the same table simultaneously — both could read the same `MAX(id)`. Acceptable for current traffic levels.

## Test plan

- [ ] Create a new record for each affected model and verify it saves without the `Field 'id' doesn't have a default value` error
- [ ] Verify IDs are sequential and don't collide with existing data

🤖 Generated with [Claude Code](https://claude.com/claude-code)