### PR TITLE
fix: assign IDs manually in bulk invoice_lines insert for TiDB

### DIFF
--- a/app/Services/FiscusService.php
+++ b/app/Services/FiscusService.php
@@ -89,13 +89,18 @@ class FiscusService
     private function createInvoiceLines(int $priceId, array $memberIds): int
     {
         // Prepare bulk insert data
+        // Note: insert() bypasses Eloquent events so IDs must be assigned manually (TiDB lacks AUTO_INCREMENT)
         $now = now();
-        $data = array_map(fn ($memberId) => [
-            'invoice_product_price_id' => $priceId,
-            'member_id' => $memberId,
-            'created_at' => $now,
-            'updated_at' => $now,
-        ], $memberIds);
+        $nextId = (int) DB::table('invoice_lines')->max('id') + 1;
+        $data = array_map(function ($memberId) use ($priceId, $now, &$nextId) {
+            return [
+                'id' => $nextId++,
+                'invoice_product_price_id' => $priceId,
+                'member_id' => $memberId,
+                'created_at' => $now,
+                'updated_at' => $now,
+            ];
+        }, $memberIds);
 
         // Bulk insert all invoice lines
         InvoiceLine::insert($data);


### PR DESCRIPTION
## Summary

- `InvoiceLine::insert()` bypasses Eloquent model events, so the `HasManualAutoIncrement` trait's `creating` callback never fires
- TiDB then rejects the insert because `id` has no default value
- Fix: fetch `max(id)` once before the bulk insert and increment in memory for each row

## Test plan

- [ ] Create/update invoice lines via the Fiscus UI and confirm no SQL error
- [ ] Verify IDs are assigned sequentially

🤖 Generated with [Claude Code](https://claude.com/claude-code)