### PR TITLE
fix: handle null product on home orders table

### DIFF
--- a/resources/views/home/index.blade.php
+++ b/resources/views/home/index.blade.php
@@ -22,7 +22,7 @@
                         <td>{{ $m->created_at }}</td>
                         <td>{{ isset($m->ownerable) ? isset($m->ownerable->name) ?  $m->ownerable->name : $m->ownerable->firstname . ' ' . $m->ownerable->lastname : 'verwijderd' }}</td>
                         <td>{{ $m->amount }}</td>
-                        <td>{{ $m->product->name }}</td>
+                        <td>{{ $m->product?->name ?? 'deleted' }}</td>
                     </tr>
                 @endforeach
                 </tbody>


### PR DESCRIPTION
## Summary

- Some orders reference products that have been deleted, causing `Attempt to read property "name" on null` on the home page
- Use null-safe operator (`?->`) with a `'deleted'` fallback, consistent with how `ownerable` is already handled on the same line

## Test plan

- [ ] Visit the home page and confirm no 500 error
- [ ] Verify orders with deleted products show "deleted" in the Product column

🤖 Generated with [Claude Code](https://claude.com/claude-code)